### PR TITLE
update openrex-spi-canvas demo, minor update in linux-openrex

### DIFF
--- a/recipes-examples/openrex-spi-canvas/files/canvas_common.h
+++ b/recipes-examples/openrex-spi-canvas/files/canvas_common.h
@@ -92,6 +92,7 @@ struct cmd_getcolor {
 struct ack_dimension {
     int32_t width;
     int32_t height;
+    uint32_t pixel_bits;
 };
 
 /* dimension acknowledge attributes */

--- a/recipes-examples/openrex-spi-canvas/files/canvascmd.c
+++ b/recipes-examples/openrex-spi-canvas/files/canvascmd.c
@@ -35,8 +35,9 @@ int32_t canvascmd_get_dimension(
     uint8_t ack = CANVAS_ACK_DIMENSION;
     struct ack_dimension dimension = { 0 };
 
-    dimension.width = fbscreen->fbunits[ fbscreen->index ].var_info.xres_virtual;
-    dimension.height = fbscreen->fbunits[ fbscreen->index ].var_info.yres_virtual;
+    dimension.width = fbscreen->var_info.xres;
+    dimension.height = fbscreen->var_info.yres;
+    dimension.pixel_bits = fbscreen->var_info.bits_per_pixel;
 
     canvas_dbg("cmd dimension: 0x%x\n", sizeof(dimension));
     canvas_dbg("width: 0x%x\n", dimension.width);

--- a/recipes-examples/openrex-spi-canvas/files/config.h
+++ b/recipes-examples/openrex-spi-canvas/files/config.h
@@ -23,8 +23,8 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-//#define canvas_dbg printf
-#define canvas_dbg 
+// #define canvas_dbg(...) printf(__VA_ARGS__)
+#define canvas_dbg(...)
 
 // #define DISABLE_TTY_PATH "/dev/tty1"
 // #define FB_DEVICE "/dev/fb0"

--- a/recipes-examples/openrex-spi-canvas/files/fbscreen.h
+++ b/recipes-examples/openrex-spi-canvas/files/fbscreen.h
@@ -42,23 +42,23 @@
 #   define CANVAS_RGBCOLOR_BLUE(color)     ((color) & 0xFF)
 #endif
 
-/* framebuffer struct */
-struct fbscreen_fbunit
-{
-    int32_t fd;
-    uint8_t *fbmem;
-    uint8_t *tmp_fbmem;
-    uint32_t use_tmp;
-    uint32_t size;
-    struct fb_var_screeninfo var_info;
-    struct fb_fix_screeninfo fix_info;
-};
 
 /* framebuffers group */
 struct fbscreen {
-    struct fbscreen_fbunit fbunits[2];
-    int32_t index;
-    int32_t limit;
+    /* famebuffer data */
+    int32_t fb_fd;
+    uint8_t *fb_mem;
+    uint32_t fb_mem_size;
+    /* screen data */
+    struct fb_var_screeninfo var_info;
+    struct fb_fix_screeninfo fix_info;
+    /* drawing data */
+    uint8_t *drawing_mem;
+    uint32_t drawing_mem_size;
+    uint32_t drawing_idx;
+    /* precalculated data for mem swap */
+    uint32_t drawing_yoffsets[2];
+    uint8_t* drawing_addrs[2];
 };
 
 /* fbscreen circle */
@@ -80,15 +80,10 @@ struct fbscreen_rectangle {
     uint32_t height;
 };
 
-// int32_t fbscreen_init(
-//     struct fbscreen *fbscreen,
-//     const char *fb_path1,
-//     const char *fb_path2
-// );
-
-int32_t fbscreen_init_single(
+int32_t fbscreen_init(
     struct fbscreen *fbscreen,
-    const char *fb_path1
+    const char *fb_path,
+    const uint8_t color_depth
 );
 
 int32_t fbscreen_deinit(
@@ -126,7 +121,7 @@ int32_t fbscreen_draw_circle(
 
 int32_t fbscreen_flush_drawing
 (
-    const struct fbscreen *fbscreen
+    struct fbscreen *fbscreen
 );
 
 #endif

--- a/recipes-kernel/linux/linux-openrex_3.14.bb
+++ b/recipes-kernel/linux/linux-openrex_3.14.bb
@@ -19,7 +19,9 @@ SRCBRANCH = "jethro"
 LOCALVERSION = "-yocto"
  
 #Always update SRCREV based on your last commit
-SRCREV = "aba8070ca2dbb941788a5f5eea714e3cf8a44b65"
+#SRCREV = "aba8070ca2dbb941788a5f5eea714e3cf8a44b65"
+SRCREV = "AUTOINC"
+
  
 KERNEL_SRC ?= "git://github.com/FEDEVEL/openrex-linux-3.14.git;protocol=git"
 SRC_URI = "${KERNEL_SRC};branch=${SRCBRANCH} file://defconfig"


### PR DESCRIPTION
- use double buffering / request double yres, draw to inactive half
- force 16bit color depth
- result is bit slower but without tearing effect
- use "AUTOINC" as SRCREV to track HEAD of 'openrex-linux' repo

